### PR TITLE
Use actual scope 3 emission categories

### DIFF
--- a/src/components/company/Scope3Emissions.astro
+++ b/src/components/company/Scope3Emissions.astro
@@ -12,6 +12,116 @@ interface Props {
 }
 
 const { emissions } = Astro.props
+
+type Scope3Category = keyof Exclude<EmissionsScope['categories'], undefined>
+
+type CategoryDefinition = {
+  title: string
+  description: string
+  Icon: astroHTML.JSX.Element
+}
+
+type ReportedCategoryDefinition = CategoryDefinition & {
+  value: number
+  category: Scope3Category
+}
+
+const categoryDefinitions: Record<Scope3Category, CategoryDefinition> = {
+  '1_purchasedGoods': {
+    title: 'Inköpta varor och tjänster',
+    description:
+      'Utsläpp från produktion av varor och tjänster som köpts av organisationen.',
+    Icon: TruckIcon,
+  },
+  '2_capitalGoods': {
+    title: 'Kapitalvaror',
+    description: '',
+    Icon: undefined,
+  },
+  '3_fuelAndEnergyRelatedActivities': {
+    title: 'Bränsle- och energirelaterade aktiviteter',
+    description: '',
+    Icon: undefined,
+  },
+  '4_upstreamTransportationAndDistribution': {
+    title: 'Uppströms transport och distribution',
+    description:
+      'Utsläpp från transport och distribution av produkter som köpts av organisationen, dvs från sina leverantörer.',
+    Icon: WarehouseIcon,
+  },
+  '5_wasteGeneratedInOperations': {
+    title: 'Avfall genererat i verksamheten',
+    description:
+      'Utsläpp från avfall som genereras av organisationens verksamhet.',
+    Icon: WormIcon,
+  },
+  '6_businessTravel': {
+    title: 'Affärsresor',
+    description:
+      'Utsläpp från transport av anställda för affärsrelaterade aktiviteter.',
+    Icon: PlaneIcon,
+  },
+  '7_employeeCommuting': {
+    title: 'Anställdas pendling',
+    description:
+      'Utsläpp från transport av anställda mellan deras hem och arbetsplatser.',
+    Icon: CompassIcon,
+  },
+  '8_upstreamLeasedAssets': {
+    title: 'Uppströms leasade tillgångar',
+    description: '',
+    Icon: undefined,
+  },
+  '9_downstreamTransportationAndDistribution': {
+    title: 'Nedströms transport och distribution',
+    description: '',
+    Icon: undefined,
+  },
+  '10_processingOfSoldProducts': {
+    title: 'Bearbetning av sålda produkter',
+    description: '',
+    Icon: undefined,
+  },
+  '11_useOfSoldProducts': {
+    title: 'Användning av sålda produkter',
+    description: '',
+    Icon: undefined,
+  },
+  '12_endOfLifeTreatmentOfSoldProducts': {
+    title: 'Slutbehandling av sålda produkter',
+    description: '',
+    Icon: undefined,
+  },
+  '13_downstreamLeasedAssets': {
+    title: 'Nedströms leasade tillgångar',
+    description: '',
+    Icon: undefined,
+  },
+  '14_franchises': { title: 'Franchiser', description: '', Icon: undefined },
+  '15_investments': {
+    title: 'Investeringar',
+    description: '',
+    Icon: undefined,
+  },
+  '16_other': { title: 'Övrigt', description: '', Icon: undefined },
+}
+
+function getReportedCategories(
+  emissions: EmissionsScope['categories'],
+): ReportedCategoryDefinition[] {
+  return emissions
+    ? Object.entries(emissions).reduce((categories, [category, value]) => {
+        if (value) {
+          categories.push({
+            ...categoryDefinitions[category as Scope3Category],
+            category: category as Scope3Category,
+            value,
+          })
+        }
+        return categories
+      }, [] as ReportedCategoryDefinition[])
+    : []
+}
 ---
 
 {
@@ -19,40 +129,16 @@ const { emissions } = Astro.props
     <div class="grid gap-4">
       <div class="font-semibold">Scope 3 utsläppskategorier</div>
       <div class="grid gap-4">
-        <Scope3EmissionsCategory
-          Icon={TruckIcon}
-          title="Köpta varor och tjänster"
-          description="Utsläpp från produktion av varor och tjänster som köpts av organisationen."
-          value={emissions['1_purchasedGoods']?.toLocaleString('sv-se')}
-        />
-        <Scope3EmissionsCategory
-          Icon={PlaneIcon}
-          title="Affärsresor"
-          description="Utsläpp från transport av anställda för affärsrelaterade aktiviteter."
-          value={emissions['6_businessTravel']?.toLocaleString('sv-se')}
-        />
-        <Scope3EmissionsCategory
-          Icon={CompassIcon}
-          title="Anställdas pendling"
-          description="Utsläpp från transport av anställda mellan deras hem och arbetsplatser."
-          value={emissions['7_employeeCommuting']?.toLocaleString('sv-se')}
-        />
-        <Scope3EmissionsCategory
-          Icon={WarehouseIcon}
-          title="Uppströms transporter och distribution"
-          description="Utsläpp från transport och distribution av produkter som köpts av organisationen, dvs från sina leverantörer."
-          value={emissions[
-            '4_upstreamTransportationAndDistribution'
-          ]?.toLocaleString('sv-se')}
-        />
-        <Scope3EmissionsCategory
-          Icon={WormIcon}
-          title="Avfall genererat i verksamheten"
-          description="Utsläpp från avfall som genereras av organisationens verksamhet."
-          value={emissions['5_wasteGeneratedInOperations']?.toLocaleString(
-            'sv-se',
-          )}
-        />
+        {getReportedCategories(emissions).map(
+          ({ Icon, title, description, value }) => (
+            <Scope3EmissionsCategory
+              {Icon}
+              {title}
+              {description}
+              value={value.toLocaleString('sv-se')}
+            />
+          ),
+        )}
       </div>
     </div>
   ) : null

--- a/src/components/company/Scope3EmissionsCategory.astro
+++ b/src/components/company/Scope3EmissionsCategory.astro
@@ -1,6 +1,6 @@
 ---
 interface Props {
-  Icon: astroHTML.JSX.Element
+  Icon?: astroHTML.JSX.Element
   title: string
   description: string
   value: string | null | undefined
@@ -14,7 +14,7 @@ const { Icon, title, description, value } = Astro.props
     <div
       class="flex aspect-square h-10 w-10 items-center justify-center rounded-md bg-gray-800"
     >
-      <Icon class="h-5 w-5" />
+      {Icon && <Icon class="h-5 w-5" />}
     </div>
     <div>
       <div class="font-medium">{title}</div>


### PR DESCRIPTION
Fix #41

- Add Swedish titles for all scope 3 categories. Descriptions and icons for the new categories will be solved in the future, as part of #43  
- Only show the scope 3 categories that were reported.
- Prepare code to make it easier to add translations. Made most sense to do it properly right away.