### PR TITLE
Feature/show verified data

### DIFF
--- a/src/components/company/CompanyEmissions.astro
+++ b/src/components/company/CompanyEmissions.astro
@@ -3,6 +3,7 @@ import { getCompanyName, type CompanyData } from '@/data/companyData'
 import { Card } from '../ui/card'
 import Scope3Emissions from './Scope3Emissions.astro'
 import CompanyFacts from './CompanyFacts.astro'
+import { cn } from '@/lib/utils'
 
 interface Props {
   company: CompanyData
@@ -33,28 +34,33 @@ const scopeEmissionsList = emissions
         subtitle: 'Totala utsläpp',
         description: '',
         value: totalEmissions,
+        verified: emissions.scope2.verified,
       },
       {
         subtitle: 'Egna utsläpp (scope 1)',
         description:
           'Utsläpp från egna källor eller kontrollerade av organisationen.',
         value: emissions.scope1.emissions,
+        verified: emissions.scope2.verified,
       },
       {
         subtitle: 'Indirekta (scope 2)',
         description:
           'Indirekta utsläpp från produktion av köpt el, ånga, värme och kyla som konsumeras av organisationen.',
         value: emissions.scope2.emissions,
+        verified: emissions.scope2.verified,
       },
       {
         subtitle: 'Värdekedjan (scope 3)',
         description: 'Indirekta utsläpp från organisationens värdekedja.',
         value: emissions.scope3.emissions,
+        verified: emissions.scope2.verified,
       },
       {
         subtitle: 'Biogena utsläpp',
         description: '',
         value: totalBiogenicEmissions,
+        verified: emissions.scope2.verified,
       },
     ]
   : []
@@ -80,7 +86,7 @@ const scopeEmissionsList = emissions
   <h2
     class="flex items-center justify-between pb-4 text-3xl leading-none tracking-tight"
   >
-    Utsläpp 2023 <span class="xs:text-xl text-base text-muted">(ton CO₂e)</span>
+    Utsläpp 2023 <span class="text-base text-muted xs:text-xl">(ton CO₂e)</span>
   </h2>
   {
     scopeEmissionsList.length ? (
@@ -94,7 +100,14 @@ const scopeEmissionsList = emissions
                   <p class="text-sm text-muted">{emission.description}</p>
                 )}
               </div>
-              <span class="rounded-full bg-gray-800 px-4 py-2 font-bold md:text-xl">
+              <span
+                class={cn(
+                  'rounded-full px-4 py-2 font-bold md:text-xl',
+                  emission.verified
+                    ? 'bg-blue-250 text-blue-950'
+                    : 'bg-gray-800',
+                )}
+              >
                 {emission.value.toLocaleString('sv-SE')}
               </span>
             </div>

--- a/src/components/company/CompanyFactSection.astro
+++ b/src/components/company/CompanyFactSection.astro
@@ -5,14 +5,21 @@ interface Props {
   title: string
   data: string | number
   class?: string
+  verified?: string | null
 }
 
-const { title, data, class: className } = Astro.props
+const { title, data, class: className, verified } = Astro.props
 ---
 
+<!-- TODO: Provide data and make these data points verified too. For this, we need new API data though. -->
 <div class={cn('flex items-center justify-between text-sm', className)}>
   <h3>{title}</h3>
-  <span class="rounded-full bg-gray-800 px-4 py-2 text-xs sm:text-sm">
+  <span
+    class={cn(
+      'rounded-full px-4 py-2 text-xs sm:text-sm',
+      verified ? 'bg-blue-250 text-blue-950' : 'bg-gray-800',
+    )}
+  >
     {data}
   </span>
 </div>

--- a/src/components/company/CompanyGoals.astro
+++ b/src/components/company/CompanyGoals.astro
@@ -10,21 +10,23 @@ interface Props {
 const { goals } = Astro.props
 ---
 
-<Card class="grid gap-4" level={1}>
-  <h2 class="pb-4 text-3xl leading-none tracking-tight">Mål</h2>
-  <ul class="grid gap-2">
-    {
-      goals.map((goal) => (
-        <li class="flex items-center gap-4">
-          <div class="flex aspect-square h-10 w-10 items-center justify-center rounded-md bg-gray-800">
-            <CheckIcon class="h-5 w-5" />
-          </div>
-          <div>
-            <div class="font-medium">{goal.description}</div>
-            <div class="text-sm text-muted">Fram till {goal.year}</div>
-          </div>
-        </li>
-      ))
-    }
-  </ul>
-</Card>
+{
+  goals ? (
+    <Card class="grid gap-4" level={1}>
+      <h2 class="pb-4 text-3xl leading-none tracking-tight">Mål</h2>
+      <ul class="grid gap-2">
+        {goals.map((goal) => (
+          <li class="flex items-center gap-4">
+            <div class="flex aspect-square h-10 w-10 items-center justify-center rounded-md bg-gray-800">
+              <CheckIcon class="h-5 w-5" />
+            </div>
+            <div>
+              <div class="font-medium">{goal.description}</div>
+              <div class="text-sm text-muted">Fram till {goal.year}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  ) : null
+}

--- a/src/components/company/CompanyInitiatives.astro
+++ b/src/components/company/CompanyInitiatives.astro
@@ -10,23 +10,25 @@ interface Props {
 const { initiatives } = Astro.props
 ---
 
-<Card class="grid gap-4" level={1}>
-  <h2 class="pb-4 text-3xl leading-none tracking-tight">
-    Initiativ och löften
-  </h2>
-  <ul class="grid gap-2">
-    {
-      initiatives.map((initiative) => (
-        <li class="flex items-center gap-4">
-          <div class="flex aspect-square h-10 w-10 items-center justify-center rounded-md bg-gray-800">
-            <CheckIcon class="h-5 w-5" />
-          </div>
-          <div>
-            <div class="font-medium">{initiative.title}</div>
-            <div class="text-sm text-muted">{initiative.description}</div>
-          </div>
-        </li>
-      ))
-    }
-  </ul>
-</Card>
+{
+  initiatives ? (
+    <Card class="grid gap-4" level={1}>
+      <h2 class="pb-4 text-3xl leading-none tracking-tight">
+        Initiativ och löften
+      </h2>
+      <ul class="grid gap-2">
+        {initiatives.map((initiative) => (
+          <li class="flex items-center gap-4">
+            <div class="flex aspect-square h-10 w-10 items-center justify-center rounded-md bg-gray-800">
+              <CheckIcon class="h-5 w-5" />
+            </div>
+            <div>
+              <div class="font-medium">{initiative.title}</div>
+              <div class="text-sm text-muted">{initiative.description}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  ) : null
+}

--- a/src/components/company/Scope3EmissionsCategory.astro
+++ b/src/components/company/Scope3EmissionsCategory.astro
@@ -1,14 +1,18 @@
 ---
+import { cn } from '@/lib/utils'
+
 interface Props {
   Icon?: astroHTML.JSX.Element
   title: string
   description: string
-  value: string | null | undefined
+  value?: string | null
+  verified?: string | null
 }
 
-const { Icon, title, description, value } = Astro.props
+const { Icon, title, description, value, verified } = Astro.props
 ---
 
+<!-- TODO: Provide data and make these data points verified too. For this, we need new API data though. -->
 <div class="flex items-center justify-between gap-4">
   <div class="flex items-center gap-4">
     <div
@@ -21,7 +25,10 @@ const { Icon, title, description, value } = Astro.props
       <div class="text-sm text-muted">{description}</div>
     </div>
   </div>
-  <span class="rounded-full bg-gray-800 px-4 py-2 text-lg font-bold sm:text-xl"
-    >{value}</span
+  <span
+    class={cn(
+      'rounded-full px-4 py-2 text-lg font-bold sm:text-xl',
+      verified ? 'bg-blue-250 text-blue-950' : 'bg-gray-800',
+    )}>{value}</span
   >
 </div>


### PR DESCRIPTION
- Show verified data for emissions. Currently only Axfood has this.
- Prepare for showing verified data points in `CompanyFacts` and `Scope3EmissionsCategory`
- Also fix a bug that crashed rendering when initiatives and goals were missing.