### PR TITLE
Fix/reorder goals and initiatives

### DIFF
--- a/src/components/company/Company.astro
+++ b/src/components/company/Company.astro
@@ -40,9 +40,9 @@ const emissions = company.emissions[year]
         <div class="mt-8 grid gap-8">
           <CompanyEmissions {company} {year} />
 
-          <CompanyInitiatives initiatives={company.initiatives} />
-
           <CompanyGoals goals={company.goals} />
+
+          <CompanyInitiatives initiatives={company.initiatives} />
 
           <div class="grid place-content-center py-16">
             <OtherCompanies client:idle {companies} />

--- a/src/components/company/CompanyFacts.astro
+++ b/src/components/company/CompanyFacts.astro
@@ -22,7 +22,7 @@ function getMonthName(month: number) {
   {
     company.industryNace.division.name && (
       <CompanyFactSection
-        title="Industri"
+        title="Bransch"
         data={company.industryNace.division.name}
         class="col-span-full flex flex-wrap justify-between gap-2"
       />

--- a/src/components/company/CompanyFacts.astro
+++ b/src/components/company/CompanyFacts.astro
@@ -33,7 +33,7 @@ function getMonthName(month: number) {
     {
       company.baseFacts[year]?.turnover && (
         <CompanyFactSection
-          title={'Omsättning ' + year}
+          title="Omsättning"
           data={
             company.baseFacts[year].turnover.toLocaleString('sv-SE') +
             ' ' +
@@ -45,7 +45,7 @@ function getMonthName(month: number) {
     {
       company.baseFacts[year]?.employees && (
         <CompanyFactSection
-          title="Anställda 2023"
+          title="Anställda"
           data={company.baseFacts[year].employees.toLocaleString('sv-SE')}
         />
       )

--- a/src/components/company/CompanyInitiatives.astro
+++ b/src/components/company/CompanyInitiatives.astro
@@ -13,9 +13,7 @@ const { initiatives } = Astro.props
 {
   initiatives ? (
     <Card class="grid gap-4" level={1}>
-      <h2 class="pb-4 text-3xl leading-none tracking-tight">
-        Initiativ och löften
-      </h2>
+      <h2 class="pb-4 text-3xl leading-none tracking-tight">Initiativ</h2>
       <ul class="grid gap-2">
         {initiatives.map((initiative) => (
           <li class="flex items-center gap-4">


### PR DESCRIPTION
fix #67 - Remove year from turnover and employees base facts
fix #66 - Update initiative title
fix #58 - Update title for industry
fix #64 -  Show CompanyGoals before CompanyInitiatives