### PR TITLE
add unit to scope 3 categories up- and downstream

### DIFF
--- a/src/components/company/Scope3Emissions.astro
+++ b/src/components/company/Scope3Emissions.astro
@@ -189,7 +189,7 @@ function getGradeColor(count: number) {
           <div class="grid gap-2">
             <h4 class="flex items-center justify-between pb-2 text-lg leading-none tracking-tight">
               Uppströms
-              <span class="text-base text-muted xs:text-lg">(ton CO₂e)</span>
+              <span class="xs:text-l text-base text-muted">(ton CO₂e)</span>
             </h4>
             {upstream.map(({ Icon, title, description, value }) => (
               <Scope3EmissionsCategory
@@ -206,7 +206,7 @@ function getGradeColor(count: number) {
           <div class="grid gap-2 pt-4">
             <h4 class="flex items-center justify-between pb-2 text-lg leading-none tracking-tight">
               Nedströms
-              <span class="text-base text-muted xs:text-lg">(ton CO₂e)</span>
+              <span class="xs:text-l text-base text-muted">(ton CO₂e)</span>
             </h4>
             {downstream.map(({ Icon, title, description, value }) => (
               <Scope3EmissionsCategory

--- a/src/components/company/Scope3Emissions.astro
+++ b/src/components/company/Scope3Emissions.astro
@@ -187,7 +187,10 @@ function getGradeColor(count: number) {
       <div class="grid gap-2 text-sm">
         {upstream.length ? (
           <div class="grid gap-2">
-            <h4 class="pb-2 text-lg leading-none tracking-tight">Uppströms</h4>
+            <h4 class="flex items-center justify-between pb-2 text-lg leading-none tracking-tight">
+              Uppströms
+              <span class="text-base text-muted xs:text-lg">(ton CO₂e)</span>
+            </h4>
             {upstream.map(({ Icon, title, description, value }) => (
               <Scope3EmissionsCategory
                 {Icon}
@@ -201,7 +204,10 @@ function getGradeColor(count: number) {
 
         {downstream.length ? (
           <div class="grid gap-2 pt-4">
-            <h4 class="pb-2 text-lg leading-none tracking-tight">Nedströms</h4>
+            <h4 class="flex items-center justify-between pb-2 text-lg leading-none tracking-tight">
+              Nedströms
+              <span class="text-base text-muted xs:text-lg">(ton CO₂e)</span>
+            </h4>
             {downstream.map(({ Icon, title, description, value }) => (
               <Scope3EmissionsCategory
                 {Icon}


### PR DESCRIPTION
Fix #89 

I added units to the Uppströms/Nedströms title sections because I believe it's more accurate to specify the unit in the "table head" (i.e., the "closest" title). Additionally, this placement looks better on smaller screens compared to including it in "X rapporterar Y / 15 kategorier:" (which was another placement option I considered).