### PR TITLE
Fix/improve empty states and caching

### DIFF
--- a/src/components/company/CompanyFacts.astro
+++ b/src/components/company/CompanyFacts.astro
@@ -70,9 +70,16 @@ function getPeriod(company: CompanyData) {
         )
       }
 
-      <a href={company.url} class="self-start text-sm text-blue-500 underline">
-        Läs hållbarhetsrapport för {getPeriod(company)}
-      </a>
+      {
+        company.url && (
+          <a
+            href={company.url}
+            class="self-start text-sm text-blue-500 underline"
+          >
+            Läs hållbarhetsrapport för {getPeriod(company)}
+          </a>
+        )
+      }
     </Card>
 
     <!-- NOTE: Maybe add total emissions in this card instead -->

--- a/src/components/company/CompanyGoals.astro
+++ b/src/components/company/CompanyGoals.astro
@@ -11,7 +11,7 @@ const { goals } = Astro.props
 ---
 
 {
-  goals ? (
+  goals && goals.length ? (
     <Card class="grid gap-8" level={1}>
       <h2 class="pt-4 text-center text-3xl leading-none tracking-tight md:pt-0">
         Mål

--- a/src/components/company/CompanyInitiatives.astro
+++ b/src/components/company/CompanyInitiatives.astro
@@ -11,7 +11,7 @@ const { initiatives } = Astro.props
 ---
 
 {
-  initiatives ? (
+  initiatives && initiatives.length ? (
     <Card class="grid gap-8" level={1}>
       <h2 class="pt-4 text-center text-3xl leading-none tracking-tight md:pt-0">
         Initiativ

--- a/src/lib/createCache.ts
+++ b/src/lib/createCache.ts
@@ -22,7 +22,7 @@ export function createCache<K, V>({ maxAge }: { maxAge: number }) {
     },
     get(key: K) {
       const value = cache.get(key)
-      if (value) {
+      if (value && Date.now() - value.cachedAt < maxAge) {
         return value.data
       }
     },


### PR DESCRIPTION
- Better handling of empty state for goals and initiatives
- Only show link to sustainability report when it exists in the data
- Prevent stale data from getting returned from the cache

Fix #124 