### PR TITLE
Fix/prevent crash for missing base facts

### DIFF
--- a/src/components/company/CompanyFacts.astro
+++ b/src/components/company/CompanyFacts.astro
@@ -104,7 +104,6 @@ const reportURL =
       }
 
       {
-        // TODO: Use the last available year instead of hard coded year
         company.baseFacts?.[year]?.turnover && (
           <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-sm">
             <h3>Omsättning ({year})</h3>
@@ -119,12 +118,11 @@ const reportURL =
         )
       }
       {
-        // TODO: Use the last available year instead of hard coded year
-        company.baseFacts[year]?.employees && (
+        company.baseFacts?.[year]?.employees && (
           <div class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-sm">
             <h3>Antal anställda ({year})</h3>
             <p class="text-sm text-orange-250">
-              {company.baseFacts[year]?.employees.toLocaleString('sv-SE', {
+              {company.baseFacts[year].employees.toLocaleString('sv-SE', {
                 maximumFractionDigits: 0,
               })}
             </p>

--- a/src/components/company/CompanyFacts.astro
+++ b/src/components/company/CompanyFacts.astro
@@ -133,7 +133,7 @@ const reportURL =
       {
         reportURL && (
           <span>
-            Läs senaste{' '}
+            Läs{' '}
             <a
               href={reportURL}
               class="self-start text-sm text-blue-500 underline"

--- a/src/components/company/Scope3EmissionsCategory.astro
+++ b/src/components/company/Scope3EmissionsCategory.astro
@@ -13,8 +13,6 @@ interface Props {
 const { Icon, title, description, value, verified } = Astro.props
 
 const hasValue = value !== null && value !== undefined
-
-// TODO: Provide data and make these data points verified too. For this, we need new API data though.
 ---
 
 <div class="flex items-start justify-between gap-4">

--- a/src/data/companyData.ts
+++ b/src/data/companyData.ts
@@ -160,7 +160,7 @@ export interface CompanyData {
   baseYear: string
   url: string
   emissions: Emissions
-  baseFacts: BaseFacts
+  baseFacts?: BaseFacts
   factors: Factors[]
   contacts: Contact[]
   goals: Goal[]


### PR DESCRIPTION
Fix #182 

It turned out this was due to the `baseFacts` missing completely for some companies.