### PR TITLE
Fix #247 - Omit devDependencies and use locked versions when installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm ci --omit=dev
 COPY . .
 RUN npm run telemetry
 ENV PORT=8080


### PR DESCRIPTION
fix #247 