### PR TITLE
Fix config for production build to include all dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:lts AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
 COPY . .
+RUN npm ci --omit=dev
 RUN npm run telemetry
 ENV PORT=8080
 ENV NODE_ENV=production

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,20 +15,6 @@
         "@astrojs/tailwind": "^5.1.3",
         "@astrojs/ts-plugin": "^1.10.4",
         "@fontsource-variable/dm-sans": "^5.1.0",
-        "astro": "^5.0.4",
-        "bits-ui": "^0.21.16",
-        "clsx": "^2.1.1",
-        "cmdk-sv": "^0.0.18",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "slugify": "^1.6.6",
-        "svelte": "^5.10.0",
-        "tailwind-merge": "^2.5.5",
-        "tailwind-variants": "^0.3.0",
-        "tailwindcss": "^3.4.16",
-        "typescript": "^5.7.2"
-      },
-      "devDependencies": {
         "@iconify-json/bi": "^1.2.1",
         "@iconify-json/clarity": "^1.2.1",
         "@iconify-json/fa6-solid": "^1.2.2",
@@ -40,14 +26,28 @@
         "@iconify-json/mingcute": "^1.2.1",
         "@iconify-json/streamline": "^1.2.1",
         "@iconify-json/zondicons": "^1.2.1",
+        "astro": "^5.0.4",
+        "bits-ui": "^0.21.16",
+        "clsx": "^2.1.1",
+        "cmdk-sv": "^0.0.18",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "slugify": "^1.6.6",
+        "svelte": "^5.10.0",
+        "tailwind-merge": "^2.5.5",
+        "tailwind-variants": "^0.3.0",
+        "tailwindcss": "^3.4.16",
+        "typescript": "^5.7.2",
+        "unplugin-icons": "^0.21.0"
+      },
+      "devDependencies": {
         "@types/node": "^22.10.1",
         "@types/react": "^18.3.9",
         "@types/react-dom": "^18.3.0",
         "prettier": "^3.4.2",
         "prettier-plugin-astro": "^0.14.1",
         "prettier-plugin-svelte": "^3.2.6",
-        "prettier-plugin-tailwindcss": "^0.6.9",
-        "unplugin-icons": "^0.21.0"
+        "prettier-plugin-tailwindcss": "^0.6.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -79,7 +79,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
       "integrity": "sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "package-manager-detector": "^0.2.0",
@@ -93,7 +92,6 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
       "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -1102,7 +1100,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/bi/-/bi-1.2.1.tgz",
       "integrity": "sha512-wsIWb6bcnBkfN8/2puIIE2ul6NYVjclbE/nI7JZsPnfzBamd3NuRFstXQH9Ckkbrw9eiBTNKwHbH90w3UE5QIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1112,7 +1109,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/clarity/-/clarity-1.2.1.tgz",
       "integrity": "sha512-xUjFG3QU/Kqcs2O7/wHAj+xLlfJvzPY0bE5C5AaspwmOnau5R+rcTCAKtDZHUUvhSq+9t7GAJ5bUO5nkzmttrA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1122,7 +1118,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@iconify-json/fa6-solid/-/fa6-solid-1.2.2.tgz",
       "integrity": "sha512-R419Oa+Tdq1AZjInDKylqfIWWIRykMwFCYr6xEEy/+mS583hV0mNYs95owMcb3GKeW92lpn9vGFckrioG1hqgQ==",
-      "dev": true,
       "license": "CC-BY-4.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1132,7 +1127,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/icon-park-outline/-/icon-park-outline-1.2.1.tgz",
       "integrity": "sha512-cNvUJL9mk3xOfyffErQuxvyRCWk0hCx1M8AEyGmNXjqIfgPC25OChCstt0KFB3IULS+hw9es+uA7pvVPmQh+AA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1142,7 +1136,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/ion/-/ion-1.2.1.tgz",
       "integrity": "sha512-33jiBdtP8+uBV0KRz8Z9g54QFujzssiT9W6wdNuY61VQM1s3cvoAX89yiczRs4/6b2xJE5vqqvsEJAQPqfY5JA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1152,7 +1145,6 @@
       "version": "1.2.18",
       "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.18.tgz",
       "integrity": "sha512-SFBoHBSULntem84iWxGM9NzlP6QY/dwjxC5t4c1lC7+xq31Fous8JkppoJih0/ICJ3CsbppRZeb11y3iLcwwug==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@iconify/types": "*"
@@ -1162,7 +1154,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/maki/-/maki-1.2.1.tgz",
       "integrity": "sha512-spJHZjSRJYZ1vDL8Tdhrd6FhvZZRZ6g0gd0RNGg6QFtWrO+rN7eCfA4nzBL6hUSfWSERFAQwS8Xopps32Q6opg==",
-      "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1172,7 +1163,6 @@
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@iconify-json/material-symbols/-/material-symbols-1.2.10.tgz",
       "integrity": "sha512-GcZxhOFStM7Dk/oZvJSaW0tR/k6NwTq+KDzYgCNBDg52ktZuRa/gkjRiYooJm/8PAe9NBYxIx8XjS/wi4sasdQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1182,7 +1172,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/mingcute/-/mingcute-1.2.1.tgz",
       "integrity": "sha512-rv682dBsjKUs1/AVg5tOegAunjCLuqyQufXU0D6Kbmgg5jMoUcl/9K2C+9MAiepBP0Eyb05YwXQvGaXMLPu/YA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1192,7 +1181,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/streamline/-/streamline-1.2.1.tgz",
       "integrity": "sha512-hqNodkjyIHBymkFY3zMip0F/D5yw4qXgwMJCaTF3zlbpQMgNJhY3D2ikTFTDVcTHfCSd6EX6enKXj4Rvu+5hnw==",
-      "dev": true,
       "license": "CC-BY-4.0",
       "dependencies": {
         "@iconify/types": "*"
@@ -1202,7 +1190,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@iconify-json/zondicons/-/zondicons-1.2.1.tgz",
       "integrity": "sha512-PDL05w4l2AqN8uPCyZ7NCb0b7AAfTPYEIn+yPEEiGzJbJ4btvhyAxHlw9H7aGyj0yPFWk3I525vwAAv0BlR/6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1212,14 +1199,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
       "version": "2.1.33",
       "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
       "integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^0.4.0",
@@ -3171,7 +3156,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -4290,7 +4274,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lilconfig": {
@@ -4361,7 +4344,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
       "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.3",
@@ -5327,7 +5309,6 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
       "integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -5572,7 +5553,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.7.tgz",
       "integrity": "sha512-g4+387DXDKlZzHkP+9FLt8yKj8+/3tOkPv7DVTJGGRm00RkEWgqbFstX1mXJ4M0VDYhUqsTOiISqNOJnhAu3PQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parse-latin": {
@@ -5671,7 +5651,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5726,7 +5705,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
       "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.1.8",
@@ -7139,7 +7117,6 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
       "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
@@ -7301,7 +7278,6 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.16.0.tgz",
       "integrity": "sha512-5liCNPuJW8dqh3+DM6uNM2EI3MLLpCKp/KY+9pB5M2S2SR2qvvDHhKgBOaTWEbZTAws3CXfB0rKTIolWKL05VQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -7315,7 +7291,6 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/unplugin-icons/-/unplugin-icons-0.21.0.tgz",
       "integrity": "sha512-sRic+yj7cCbpDFwrRj+m55ogOZi6PQRDc/WUEmjHLAnc90v0g5UVxE0cVAZgBOsAPCieizZJui/sgrCYrVx8mQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^0.5.0",
@@ -7362,7 +7337,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.5.0.tgz",
       "integrity": "sha512-dKnk2xlAyC7rvTkpkHmu+Qy/2Zc3Vm/l8PtNyIOGDBtXPY3kThfU4ORNEp3V7SXw5XSOb+tOJaUYpfquPzL/Tg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "package-manager-detector": "^0.2.5",
@@ -8197,7 +8171,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5369,9 +5369,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
+      "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
       "funding": [
         {
           "type": "github",
@@ -5878,9 +5878,9 @@
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwind-variants": "^0.3.0",
     "tailwindcss": "^3.4.16",
-    "typescript": "^5.7.2"
-  },
-  "devDependencies": {
+    "typescript": "^5.7.2",
     "@iconify-json/bi": "^1.2.1",
     "@iconify-json/clarity": "^1.2.1",
     "@iconify-json/fa6-solid": "^1.2.2",
@@ -45,14 +43,16 @@
     "@iconify-json/mingcute": "^1.2.1",
     "@iconify-json/streamline": "^1.2.1",
     "@iconify-json/zondicons": "^1.2.1",
+    "unplugin-icons": "^0.21.0"
+  },
+  "devDependencies": {
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.9",
     "@types/react-dom": "^18.3.0",
     "prettier": "^3.4.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-svelte": "^3.2.6",
-    "prettier-plugin-tailwindcss": "^0.6.9",
-    "unplugin-icons": "^0.21.0"
+    "prettier-plugin-tailwindcss": "^0.6.9"
   },
   "overrides": {
     "@melt-ui/svelte": {


### PR DESCRIPTION
- Copy files before `npm ci` to fix postinstall scripts during CI. This should include the `astro.config.ts` which seems to be required before we can install `astro` or some other dependency.
- Fix low impact security issue.
- Fix CI build by including all actual dependencies as part of the `dependencies`. Previously, some critical packages like `unplugin-icons` and the icon packs were incorrectly added as `devDependencies`. The strange thing is that this is the officially recommended way to install these packages as per the `unplugin-icons` README.