### PR TITLE
[Fix] Update Github Link in Footer

### DIFF
--- a/src/components/footer/Footer.astro
+++ b/src/components/footer/Footer.astro
@@ -17,7 +17,7 @@ import Socials from './Socials.svelte'
         Klimatkollen är en medborgarplattform som tillgängliggör klimatdata och
         är utvecklad med {' '}
         <a
-          href="https://github.com/Klimatbyran/klimatkollen"
+          href="https://github.com/Klimatbyran/"
           target="_bland"
           class="underline"
         >

--- a/src/components/footer/Socials.svelte
+++ b/src/components/footer/Socials.svelte
@@ -8,7 +8,7 @@
   export let items: SocialListItemProps[] = [
     { link: "https://x.com/klimatkollen", text: "X", icon: "/icons/some/x_white.svg" },
     { link: "https://www.linkedin.com/company/klimatkollen/", text: "LinkedIn", icon: "/icons/some/linkedin_white.svg" },
-    { link: "https://github.com/Klimatbyran/klimatkollen", text: "GitHub", icon: "/icons/some/github.svg" },
+    { link: "https://github.com/Klimatbyran/", text: "GitHub", icon: "/icons/some/github.svg" },
     { link: "https://discord.gg/FPX9yqYAmk", text: "Discord", icon: "/icons/some/discord.svg" },
     { link: "https://instagram.com/klimatkollen.se", text: "Instagram", icon: "/icons/some/Instagram_Glyph_Black.svg" },
     { link: "https://www.facebook.com/klimatkollen/", text: "Facebook", icon: "/icons/some/facebook.svg" }


### PR DESCRIPTION
## What's Changed
In the footer, updating the github link to point to the organisation page rather than a specific repository for both the socials icon and footer text. 

[Linked Issue](https://github.com/Klimatbyran/beta/issues/274)

### Impact
No visual change, just a change to the link. 