### PR TITLE
Include lucide-react in Vite config's optimizeDeps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import path from 'path';
-import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import path from "path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
 
 // Cache storage for API responses
 const apiCache = new Map();
@@ -11,61 +11,61 @@ export default defineConfig({
       // Add babel configuration to remove defaultProps warnings
       babel: {
         plugins: [
-          ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
-          ['@babel/plugin-proposal-class-properties', { loose: true }]
-        ]
-      }
-    })
+          ["@babel/plugin-transform-react-jsx", { runtime: "automatic" }],
+          ["@babel/plugin-proposal-class-properties", { loose: true }],
+        ],
+      },
+    }),
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   optimizeDeps: {
-    exclude: ['lucide-react'],
+    include: ["lucide-react"],
   },
   server: {
     proxy: {
-      '/api': {
-        target: 'https://api.klimatkollen.se',
+      "/api": {
+        target: "https://api.klimatkollen.se",
         changeOrigin: true,
         secure: true,
-        rewrite: (path) => path.replace(/^\/api/, '/api'),
+        rewrite: (path) => path.replace(/^\/api/, "/api"),
         configure: (proxy) => {
-          proxy.on('proxyReq', (proxyReq, req) => {
+          proxy.on("proxyReq", (proxyReq, req) => {
             // Generate cache key from request URL and method
             const cacheKey = `${req.method}:${req.url}`;
-            
+
             // Store the original URL for cache hits
             req.originalUrl = req.url;
           });
 
-          proxy.on('proxyRes', (proxyRes, req, res) => {
+          proxy.on("proxyRes", (proxyRes, req, res) => {
             const cacheKey = `${req.method}:${req.originalUrl}`;
-            
+
             // Only cache GET requests
-            if (req.method === 'GET') {
-              let body = '';
-              proxyRes.on('data', chunk => body += chunk);
-              proxyRes.on('end', () => {
+            if (req.method === "GET") {
+              let body = "";
+              proxyRes.on("data", (chunk) => (body += chunk));
+              proxyRes.on("end", () => {
                 // Store response in cache with headers
                 apiCache.set(cacheKey, {
                   body,
                   headers: proxyRes.headers,
                   timestamp: Date.now(),
                   // Cache for 5 minutes
-                  maxAge: 5 * 60 * 1000
+                  maxAge: 5 * 60 * 1000,
                 });
               });
             }
           });
 
-          proxy.on('proxyReq', (proxyReq, req, res) => {
+          proxy.on("proxyReq", (proxyReq, req, res) => {
             const cacheKey = `${req.method}:${req.originalUrl}`;
             const cached = apiCache.get(cacheKey);
 
-            if (cached && req.method === 'GET') {
+            if (cached && req.method === "GET") {
               const now = Date.now();
               // Check if cache is still valid
               if (now - cached.timestamp < cached.maxAge) {
@@ -79,9 +79,9 @@ export default defineConfig({
               }
             }
           });
-        }
+        },
       },
     },
   },
-  base: '/',
+  base: "/",
 });


### PR DESCRIPTION
Include, instead of exclude, lucide-react in Vite config's optimizeDeps in order to fix blank page when run locally.