### PR TITLE
Update Ingress and Network Policy to Use the Correct Namespace

### DIFF
--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: frontend
   annotations:
-    cert-manager.io/cluster-issuer: 'letsencrypt-prod'
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   ingressClassName: nginx
   tls:

--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -1,12 +1,12 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: klimatkollen-frontend-network-policy
-  namespace: klimatkollen
+  name: frontend-network-policy
+  namespace: frontend
 spec:
   podSelector:
     matchLabels:
-      app: klimatkollen-frontend
+      app: frontend
   policyTypes:
     - Ingress
     - Egress


### PR DESCRIPTION
- Align namespaces: Update ingress.yaml and networkpolicy.yaml to match the frontend and frontend-stage namespaces instead of klimatkollen.
- Ensure correct traffic routing: Modify networkpolicy.yaml selectors to correctly allow traffic between services within the intended namespace.

Hi think this is what is setting us back and not allow to view the latest staging branch commit on the frontend url