### PR TITLE
fix/removed namepace designation

### DIFF
--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: frontend
-  namespace: frontend-stage
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
@@ -20,6 +19,5 @@ spec:
             backend:
               service:
                 name: frontend
-                namespace: frontend-stage
                 port:
                   number: 80


### PR DESCRIPTION
Troubleshooting why the stage env is not referencing the correct branch. Trying removing the namespace call out in the ingress.yaml. 