### PR TITLE
Alt fix to company card text overflowing when theres larger numbers

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -72,7 +72,7 @@ export function CompanyCard({
     <div className="relative rounded-level-2">
       <Link
         to={`/companies/${wikidataId}`}
-        className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
+        className="block bg-black-2 rounded-level-2 p-5 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
       >
         <div className="flex items-start justify-between rounded-level-2">
           <div className="space-y-2">
@@ -126,7 +126,7 @@ export function CompanyCard({
           </div>
         </div>
         <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
+          <div className="space-y-2 ">
             <div className="flex items-center gap-2 text-grey mb-2 text-lg">
               <TrendingDown className="w-4 h-4" />
               <span>Utsläpp</span>
@@ -141,7 +141,7 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-3xl font-light">
+            <div className="text-2xl font-light">
               {currentEmissions ? (
                 <span className="text-orange-3">
                   {Math.ceil(currentEmissions).toLocaleString("sv-SE")}
@@ -170,11 +170,11 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-3xl font-light">
+            <div className="text-2xl font-light text-center">
               {emissionsChange !== null ? (
                 <span
                   className={
-                    emissionsChange < 0 ? "text-green-3" : "text-pink-3"
+                    emissionsChange < 0 ? "text-green-3" : "text-pink-3" 
                   }
                 >
                   {emissionsChange > 0 ? "+" : ""}


### PR DESCRIPTION
Noticed that on the companies with bigger numbers there was a tendency to overflow. Reduced the padding on the card, changed to smaller fontsize as well as aligned text to center. Thoughts on this? I played around abit as well with moving around the tCo2e element to free up space, but couldnt find a nice spot! :)
![before](https://github.com/user-attachments/assets/f5dec4a9-923b-46f6-a0cd-4489ce3e131a)
![after](https://github.com/user-attachments/assets/3c5df863-6af0-4670-852b-87f07d3e3911)
