### PR TITLE
fix-company card text overlapping on mobile screens

### DIFF
--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -72,7 +72,7 @@ export function CompanyCard({
     <div className="relative rounded-level-2">
       <Link
         to={`/companies/${wikidataId}`}
-        className="block bg-black-2 rounded-level-2 p-8 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
+        className="block bg-black-2 rounded-level-2 p-5 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
       >
         <div className="flex items-start justify-between rounded-level-2">
           <div className="space-y-2">
@@ -126,7 +126,7 @@ export function CompanyCard({
           </div>
         </div>
         <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
+          <div className="space-y-2 ">
             <div className="flex items-center gap-2 text-grey mb-2 text-lg">
               <TrendingDown className="w-4 h-4" />
               <span>Utsläpp</span>
@@ -141,7 +141,7 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-3xl font-light">
+            <div className="text-2xl font-light">
               {currentEmissions ? (
                 <span className="text-orange-3">
                   {Math.ceil(currentEmissions).toLocaleString("sv-SE")}
@@ -170,11 +170,11 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-3xl font-light">
+            <div className="text-2xl font-light text-center">
               {emissionsChange !== null ? (
                 <span
                   className={
-                    emissionsChange < 0 ? "text-green-3" : "text-pink-3"
+                    emissionsChange < 0 ? "text-green-3" : "text-pink-3" 
                   }
                 >
                   {emissionsChange > 0 ? "+" : ""}

--- a/src/components/companies/list/CompanyCard.tsx
+++ b/src/components/companies/list/CompanyCard.tsx
@@ -72,7 +72,7 @@ export function CompanyCard({
     <div className="relative rounded-level-2">
       <Link
         to={`/companies/${wikidataId}`}
-        className="block bg-black-2 rounded-level-2 p-5 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
+        className="block bg-black-2 rounded-level-2 p-10 xxs:p-4 xs:p-4 2xl:p-10 space-y-8 transition-all duration-300 hover:shadow-[0_0_30px_rgba(153,207,255,0.15)] hover:bg-[#1a1a1a]"
       >
         <div className="flex items-start justify-between rounded-level-2">
           <div className="space-y-2">
@@ -127,8 +127,8 @@ export function CompanyCard({
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2 ">
-            <div className="flex items-center gap-2 text-grey mb-2 text-lg">
-              <TrendingDown className="w-4 h-4" />
+            <div className="flex items-center text-center gap-2 text-grey mb-2 text-lg">
+              <TrendingDown className="w- h-4" />
               <span>Utsläpp</span>
               <TooltipProvider>
                 <Tooltip>
@@ -141,7 +141,7 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-2xl font-light">
+            <div className="xxs:text-xl xs:text-2xl text-2xl font-light">
               {currentEmissions ? (
                 <span className="text-orange-3">
                   {Math.ceil(currentEmissions).toLocaleString("sv-SE")}
@@ -170,7 +170,7 @@ export function CompanyCard({
                 </Tooltip>
               </TooltipProvider>
             </div>
-            <div className="text-2xl font-light text-center">
+            <div className="xxs:text-xl xs:text-2xl font-light xxs:text-center xs:text-center sm:text-left lg:text-left">
               {emissionsChange !== null ? (
                 <span
                   className={

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,9 +11,6 @@ export default {
     container: {
       center: true,
       padding: '2rem',
-      screens: {
-        '2xl': '1400px',
-      },
     },
     extend: {
       fontFamily: {
@@ -25,6 +22,11 @@ export default {
           letterSpacing: '-0.02em',
           fontWeight: '300',
         }],
+      },
+      screens: {
+        'xxs': '375px',
+        'xs': '430px',
+        '2xl': '1400px'
       },
       borderRadius: {
         'level-1': '48px',


### PR DESCRIPTION
Saw that there was quite heavy text-overlap with companies reporting the bigger emission numbers on mobile screens. On this fix I've added some mobile breakpoints to the tailwind.config.js as well as fixed the overlapping on screen from 375px and up. Have had to change up padding and textsizes on some breakpoints as well as text-align center on smaller screens, and then back to left when exiting mobile widths.

![before](https://github.com/user-attachments/assets/3c00bde6-7b65-406e-8190-c0a973952040)
![after](https://github.com/user-attachments/assets/739fb051-6dcb-40ac-95b3-73dd331bd60f)

