### PR TITLE
Fix proxy with api suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the new version of [klimatkollen.se](https://klimatkollen.se). You can find our legacy code [here](https://github.com/Klimatbyran/klimatkollen).
 
-We are rebuilding our site to be faster, better, and stronger using TypeScript, React, Vite, and Tailwind CSS. This is also where our new UX/UI is implemented.
+We are rebuilding our site to be faster, better, and stronger using TypeScript, React, Vite, and Tailwind CSS. This is also where our new UX/UI is implemented
 
 ## 🚀 Project Structure
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: API_BASE_URL,
+        target: `${API_BASE_URL}/api`,
         changeOrigin: true,
         secure: true,
         configure: (proxy) => {


### PR DESCRIPTION
- I think our current logic removes the suffix /api leading to calls to ex: api.klimatkollen.se/companies without the api part of the url. Easy fix, lets try it