### PR TITLE
Dynamic Github Callback URL

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,91 +4,106 @@ import { jwtDecode } from "jwt-decode";
 import { nanoid } from "nanoid";
 import React, { useContext, createContext, useState } from "react";
 
-
 export interface AuthContext {
-    token: string
-    login: (code: string, state: string) => Promise<boolean>
-    logout: () => void,
-    isAuthentificated: () => boolean,
-    getAuthUrl: () => string,
-    parseToken: () => Token | null
+  token: string;
+  login: (code: string, state: string) => Promise<boolean>;
+  logout: () => void;
+  isAuthentificated: () => boolean;
+  getAuthUrl: () => string;
+  parseToken: () => Token | null;
 }
-
 
 const AuthContext = createContext<AuthContext>({} as AuthContext);
 
 export const useAuth = () => {
-    return useContext(AuthContext);
+  return useContext(AuthContext);
 };
 
-const AuthProvider = ({children}: {children: React.ReactNode}) => {
-    const [token, setToken] = useState(localStorage.getItem("token") || "");
+const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [token, setToken] = useState(localStorage.getItem("token") || "");
 
-    const login = async (code: string, state: string) => {       
-        try {
-            const stateParts = state.split(":");
-            const oauthState = localStorage.getItem(stateParts[0]);
-            localStorage.removeItem(stateParts[0]);
-            
-            if(stateParts[1] !== oauthState) {
-                console.log("error");
-                throw new Error("States do not match up");
-            }
+  const login = async (code: string, state: string) => {
+    try {
+      const stateParts = state.split(":");
+      const oauthState = localStorage.getItem(stateParts[0]);
+      localStorage.removeItem(stateParts[0]);
 
-            const response = await authenticateWithGithub(code);
-            if (response.token) {
-                localStorage.setItem('token', response.token);
-            }
-            return true;
-            } catch (error) {
-                console.error('Login error', error);
-                throw error;
-            }
+      if (stateParts[1] !== oauthState) {
+        console.log("error");
+        throw new Error("States do not match up");
+      }
+
+      const response = await authenticateWithGithub(code);
+      if (response.token) {
+        localStorage.setItem("token", response.token);
+      }
+      return true;
+    } catch (error) {
+      console.error("Login error", error);
+      throw error;
     }
-    
-    const isAuthentificated = () => {
-        const parsedToken = parseToken();
-        if(parsedToken !== null) {
-            return parsedToken.exp > (Date.now() / 1000)
-        }
-        return false;
+  };
+
+  const isAuthentificated = () => {
+    const parsedToken = parseToken();
+    if (parsedToken !== null) {
+      return parsedToken.exp > Date.now() / 1000;
     }
+    return false;
+  };
 
-    const parseToken = () => {
-        const token = localStorage.getItem('token');
-        if (!token) return null;
-        
-        try {
-            return jwtDecode(token) as Token;
-        } catch (error) {
-        console.error('Token decode error', error);
-            return null;
-        }
+  const parseToken = () => {
+    const token = localStorage.getItem("token");
+    if (!token) return null;
+
+    try {
+      return jwtDecode(token) as Token;
+    } catch (error) {
+      console.error("Token decode error", error);
+      return null;
     }
+  };
 
-    const getAuthUrl = () => {
-         const oauthState: string = nanoid(10);
-         const oauthStateKey: string = nanoid(5);
- 
-         localStorage.setItem(oauthStateKey, oauthState);
- 
-         const authUrl = "https://github.com/login/oauth/authorize?" + 
-         "client_id=Ov23liXxnsQCvlF3VVnH" +
-         "&redirect_uri=" + encodeURIComponent("http://localhost:5173/auth/callback") +
-         "&scope=user:email,%20read:org" +
-         "&state=" + oauthStateKey + ":" + oauthState;
- 
-         return authUrl;
-    }
+  const getAuthUrl = () => {
+    const oauthState: string = nanoid(10);
+    const oauthStateKey: string = nanoid(5);
 
-    const logout = () => {
-        setToken("");
-        localStorage.removeItem("token");
-    };
+    localStorage.setItem(oauthStateKey, oauthState);
+    const redirectUri = `${window.location.origin}/auth/callback`;
 
-    return (<AuthContext.Provider value={{token, login, logout, isAuthentificated, getAuthUrl, parseToken}}>
-        {children}
-    </AuthContext.Provider>);  
-}
+    const authUrl =
+      "https://github.com/login/oauth/authorize?" +
+      "client_id=Ov23liXxnsQCvlF3VVnH" +
+      "&redirect_uri=" +
+      encodeURIComponent(redirectUri) +
+      "&scope=user:email,%20read:org" +
+      "&state=" +
+      oauthStateKey +
+      ":" +
+      oauthState;
+
+    return authUrl;
+  };
+
+  const logout = () => {
+    setToken("");
+    localStorage.removeItem("token");
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        token,
+        login,
+        logout,
+        isAuthentificated,
+        getAuthUrl,
+        parseToken,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
 
 export default AuthProvider;


### PR DESCRIPTION
💡 Context:
    - The callback URL needed to be dynamic based on the environment (Prod/Staging/Dev).
    - Hardcoding it was causing issues in different environments.

🔧 Fix:
    - Replaced the static callback URL with window.location.href to dynamically adapt to the current environment.

🔒 Security Consideration:
    - GitHub Client ID is not a secret and can be safely used in the frontend ([GitHub Docs](https://github.blog/changelog/2024-05-01-github-apps-can-now-use-the-client-id-to-fetch-installation-tokens/#:~:text=Client%20IDs%20and%20application%20IDs,JWT%20for%20a%20GitHub%20App'.)).
    - No exposure of Client Secret or sensitive credentials.

✅ Expected Behavior:
    - The correct callback URL is used in each environment without requiring manual changes.