### PR TITLE
418 Comment out company ranked list and change grid

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -146,19 +146,23 @@ export function LandingPage() {
           <h2 className="text-4xl md:text-5xl font-light text-center mb-8 md:mb-16">
             {t("landingPage.bestPerformers")}
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 gap-6">
+            {" "}
+            {/* FIXME add 2 columns for md when reintroducing company ranked list*/}
             <RankedList
               title={t("landingPage.bestMunicipalities")}
               description={t("landingPage.municipalitiesDescription")}
               items={topMunicipalities}
               type="municipality"
             />
+            {/* FIXME reintroduce at a later stage with replaced items since emissions change rate is missleading.
+            Could for instance be replaced with biggest emittiors in tCO2e
             <RankedList
               title={t("landingPage.bestCompanies")}
               description={t("landingPage.companiesDescription")}
               items={topCompanies}
               type="company"
-            />
+            /> */}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Quick fix for faulty company ranking. Reintroduce at a later stage with other values than emissions change percent last two years since ranking on that is misleading seing to how our data looks before historical gaps are filled.

I've added an issue related to this reintroduction: #431