### PR TITLE
Feat/www redirect

### DIFF
--- a/k8s/overlays/production/ingress-patch.yaml
+++ b/k8s/overlays/production/ingress-patch.yaml
@@ -21,13 +21,3 @@ spec:
                 name: frontend
                 port:
                   number: 80
-    - host: www.klimatkollen.se
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: frontend
-                port:
-                  number: 80

--- a/k8s/overlays/production/ingress-patch.yaml
+++ b/k8s/overlays/production/ingress-patch.yaml
@@ -2,13 +2,26 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: frontend
+  annotations:
+    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
 spec:
   tls:
     - hosts:
         - klimatkollen.se
+        - www.klimatkollen.se
       secretName: frontend-klimatkollen-tls
   rules:
     - host: klimatkollen.se
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+    - host: www.klimatkollen.se
       http:
         paths:
           - path: /

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "klimatkollen",
-  "version": "3.4.1-rc.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "klimatkollen",
-      "version": "3.4.1-rc.0",
+      "version": "3.4.1",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klimatkollen",
   "private": true,
-  "version": "3.4.1-rc.0",
+  "version": "3.4.1",
   "type": "module",
   "scripts": {
     "dev": "npm run generate-api && vite",


### PR DESCRIPTION
This pull request includes a small but significant change to the `k8s/overlays/production/ingress-patch.yaml` file. The change adds a new annotation to enable redirecting from non-www to www URLs and updates the TLS configuration to include the `www.klimatkollen.se` host.

* Added an annotation to enable redirecting from non-www to www URLs in the `Ingress` resource.
* Updated the TLS configuration to include the `www.klimatkollen.se` host.