### PR TITLE
[Feat] Make sure the footer is on the bottom on short pages

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,9 +8,9 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen bg-black-3">
+    <div className="min-h-screen bg-black-3 flex flex-col">
       <Header />
-      <main className="container mx-auto px-4 pt-24 pb-12">{children}</main>
+      <main className="grow container mx-auto px-4 pt-24 pb-12">{children}</main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
I noticed that the footer was not pushed to the bottom on shorter pages. Here's a small PR to fix that.

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/8163be73-86f1-4362-9768-9b187d4d665a) | ![after](https://github.com/user-attachments/assets/c811c867-d24e-4e0c-bed2-cca9007c8016) |





