### PR TITLE
[FIX] Read client ID from env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Client ID for GitHub OAuth app
+VITE_GITHUB_CLIENT_ID=

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -79,10 +79,9 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     localStorage.setItem(oauthStateKey, oauthState);
 
     const redirectUri = `${window.location.origin}/auth/callback`;
-    const environment = import.meta.env.VITE_NODE_ENV;
 
     let app_client_id;
-    switch (environment) {
+    switch (process.env.NODE_ENV) {
       case "production":
         app_client_id = "Ov23liRK6WrVG8jPDU5M";
         break;
@@ -92,6 +91,8 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       default:
         app_client_id = "Ov23liXxnsQCvlF3VVnH";
     }
+
+    console.log(process.env.NODE_ENV, app_client_id)
 
     return `https://github.com/login/oauth/authorize?client_id=${app_client_id}&redirect_uri=${encodeURIComponent(
       redirectUri

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -92,8 +92,6 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         app_client_id = "Ov23liXxnsQCvlF3VVnH";
     }
 
-    console.log(process.env.NODE_ENV, app_client_id)
-
     return `https://github.com/login/oauth/authorize?client_id=${app_client_id}&redirect_uri=${encodeURIComponent(
       redirectUri
     )}&scope=user:email,%20read:org&state=${oauthStateKey}:${oauthState}`;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -80,19 +80,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
     const redirectUri = `${window.location.origin}/auth/callback`;
 
-    let app_client_id;
-    switch (process.env.NODE_ENV) {
-      case "production":
-        app_client_id = "Ov23liRK6WrVG8jPDU5M";
-        break;
-      case "staging":
-        app_client_id = "Ov23liKHcV6ZlmTZqOtv";
-        break;
-      default:
-        app_client_id = "Ov23liXxnsQCvlF3VVnH";
-    }
-
-    return `https://github.com/login/oauth/authorize?client_id=${app_client_id}&redirect_uri=${encodeURIComponent(
+    return `https://github.com/login/oauth/authorize?client_id=${import.meta.env.VITE_GITHUB_CLIENT_ID}&redirect_uri=${encodeURIComponent(
       redirectUri
     )}&scope=user:email,%20read:org&state=${oauthStateKey}:${oauthState}`;
   };


### PR DESCRIPTION
We now read the GitHub client ID from a Vite environment variable in order to generate correct callback URLs when starting logins.